### PR TITLE
Handle wildcard routes that are not solo

### DIFF
--- a/src/Actions/WafRule.php
+++ b/src/Actions/WafRule.php
@@ -292,12 +292,14 @@ class WafRule
         $routes = $routes ?? $this->routes;
         $expression = 'not (';
 
+        // Anything containing a wildcard character should use the Cloudflare `wildcard` operator.
         $wildcards = $routes->filter(function ($route) {
-            return Str::endsWith($route, '/*');
+            return $this->containsWildcard($route);
         });
 
+        // Everything else (no wildcard characters) can be grouped in the `in {}` set.
         $paths = $routes->filter(function ($route) {
-            return ! Str::endsWith($route, '/*');
+            return ! $this->containsWildcard($route);
         });
 
         if ($wildcards->isNotEmpty()) {

--- a/tests/Feature/WafRuleTest.php
+++ b/tests/Feature/WafRuleTest.php
@@ -123,4 +123,20 @@ class WafRuleTest extends TestCase
         $condensed = (new WafRule)->condense($paths);
         $this->assertEquals($expected, $condensed);
     }
+
+    #[Test]
+    public function it_properly_groups_routes_with_trailing_wildcards_in_the_wildcard_group(): void
+    {
+        $paths = collect([
+            '/@*',
+            '/prefix*',
+        ]);
+
+        $rule = new WafRule;
+        $optimized = $rule->optimize($paths);
+
+        $expected = 'not (http.request.uri.path wildcard "/@*" or http.request.uri.path wildcard "/prefix*")';
+
+        $this->assertEquals($expected, $rule->expression());
+    }
 }


### PR DESCRIPTION
This PR handles routes where there is a wildcard but it is not alone.  For example: 

```php
Route::get('/@{username}', [ProfileController::class, 'show']));
```

This route would have been evaluated as `/@*` but due to the original logic, would have been classified as an individual route, rather than a wildcard. We are now more permissive and find any routes with the `*` character anywhere in them and if so, classify them as a wildcard.

Fixes #3 