### PR TITLE
Add explicit `--all` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Purge all cached content or specific paths/routes:
 
 ```sh
 # Purge all cache
-php artisan cloudflare:purge
+php artisan cloudflare:purge --all
 
 # Purge specific paths (absolute or relative, separated by spaces, wildcards supported)
 php artisan cloudflare:purge / /about https://example.com/faq https://example.com/our-team/*
@@ -81,16 +81,22 @@ CFCACHE_ZONE_ID=your-zone-id-here
     - Go to [Cloudflare Dashboard](https://dash.cloudflare.com/profile/api-tokens)
     - Click "Create Token"
     - Use the "Custom token" template
-    - Grant the following permissions (choose based on features you need):
-        - Zone -> Firewall Services -> Edit (for WAF rule management)
-        - Zone -> Cache Purge -> Edit (for cache purging)
-    - Include your specific zone in the Zone Resources
+    - Name the token "CFCache package token"
+    - Based on the features you need, grant the following permissions:
+        - **WAF rules**: Zone -> Firewall Services -> Edit
+        - **Cache purging**: Zone -> Cache Purge -> Purge
+    - Include your specific zone(s) in the Zone Resources
     - Create the token and copy it to your `.env` file as `CFCACHE_API_TOKEN`
 
 2. **Zone ID**:
     - Go to your domain's overview page in Cloudflare
     - Find the Zone ID in the right sidebar under "API"
     - Copy it to your `.env` file as `CFCACHE_ZONE_ID`
+
+> [!NOTE]  
+> You may create a single token that applies to multiple zones, but ensure that you
+> use the correct zone ID as the `CFCACHE_ZONE_ID` in each respective app's
+> `.env` file.
 
 #### Sync to Cloudflare API
 
@@ -170,7 +176,7 @@ This package also provides commands to purge Cloudflare's cache for specific pat
 Purge all cached content from Cloudflare:
 
 ```sh
-php artisan cloudflare:purge-cache
+php artisan cloudflare:purge-cache --all
 ```
 
 ### Purge Specific Paths

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ This package also provides commands to purge Cloudflare's cache for specific pat
 Purge all cached content from Cloudflare:
 
 ```sh
-php artisan cloudflare:purge-cache --all
+php artisan cloudflare:purge --all
 ```
 
 ### Purge Specific Paths

--- a/src/Commands/PurgeCache.php
+++ b/src/Commands/PurgeCache.php
@@ -35,7 +35,7 @@ class PurgeCache extends Command
             ->values();
 
         if ($paths->isEmpty()) {
-            $this->warn('You must specify a path or route to purge. Or purge everything with `--all`.');
+            $this->warn('You must specify at least one path or route to purge. Or purge everything with `--all`.');
 
             return;
         }
@@ -93,6 +93,8 @@ class PurgeCache extends Command
 
     protected function purgeAll(): void
     {
+        $this->info('Purging all cached content from Cloudflare...');
+
         try {
             $service = app(CachePurgeService::class);
             $result = $service->purgeCache();

--- a/src/Commands/PurgeCache.php
+++ b/src/Commands/PurgeCache.php
@@ -15,10 +15,19 @@ class PurgeCache extends Command
 
     protected $signature = 'cloudflare:purge
                             {paths?* : Paths to purge (relative or full URLs). If omitted, purges all cache}
-                            {--route=* : Route names to resolve and purge}';
+                            {--route=* : Route names to resolve and purge}
+                            {--all : Purge all cached content from Cloudflare}';
 
     public function handle(): void
     {
+        if ($this->option('all')) {
+            if ($this->confirm('Are you sure you want to purge all cached content from Cloudflare?')) {
+                $this->purgeAll();
+            }
+
+            return;
+        }
+
         $paths = $this->argument('paths');
         $routes = $this->option('route');
 
@@ -41,8 +50,9 @@ class PurgeCache extends Command
         $allPaths = $allPaths->unique()->values();
 
         if ($allPaths->isEmpty()) {
-            $this->info('Purging all cached content from Cloudflare...');
-            $this->purgeAll();
+            $this->warn('You must specify a path or route to purge. Or purge everything with `--all`.');
+
+            return;
         } else {
             $this->info('Purging specified paths from Cloudflare cache:');
             foreach ($allPaths as $path) {


### PR DESCRIPTION
This adds an explicit `--all` option to clear everything from the Cloudflare page cache instead of it being the default behavior. It also adds a confirmation as this is a pretty impactful command.

Also did a bit of refactoring with collection pipelines and other command messaging.