### PR TITLE
Add checks for missing config settings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ['8.2', '8.3', '8.4']
+        php-version: ["8.2", "8.3", "8.4"]
         laravel-version: [12]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
@@ -60,4 +60,4 @@ jobs:
           composer update --prefer-dist --no-interaction
 
       - name: Run tests
-        run: vendor/bin/phpunit
+        run: vendor/bin/pest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ["8.2", "8.3", "8.4"]
+        php-version: ["8.3", "8.4"]
         laravel-version: [12]
         os: [ubuntu-latest, windows-latest, macos-latest]
 

--- a/README.md
+++ b/README.md
@@ -12,12 +12,18 @@ purging cached content.
 
 The WAF rule generation was inspired by Jason McCreary's tweet: [https://x.com/gonedark/status/1978458884948775294](https://x.com/gonedark/status/1978458884948775294)
 
+> [!WARNING]
+> This package is still in development and so APIs and features may change
+> without notice. Please be extremely careful if you use this package in
+> production. The tagging of v1.0 will be the indication that the package is
+> stable and ready for general production use.
+
 ## Requirements
 
 A Laravel application running Laravel 12 or higher. _Not running a stable
 version of Laravel?_ [Upgrade with Shift](https://laravelshift.com).
 
-## Installation
+## Installation / Updating
 
 You can install this package by running the following command:
 
@@ -30,6 +36,11 @@ To publish the configuration file (needed for WAF rule syncing):
 ```sh
 php artisan vendor:publish --tag=cfcache-config
 ```
+
+> [!REMINDER]
+> When updating to a new v0.x (pre-v1.0) version, you will need to manually
+> update your `composer.json` file to include the new version number before
+> running `composer update`
 
 ### Basic Usage
 

--- a/README.md
+++ b/README.md
@@ -37,10 +37,11 @@ To publish the configuration file (needed for WAF rule syncing):
 php artisan vendor:publish --tag=cfcache-config
 ```
 
-> [!REMINDER]
+> [!TIP]
 > When updating to a new v0.x (pre-v1.0) version, you will need to manually
 > update your `composer.json` file to include the new version number before
-> running `composer update`
+> running `composer update` This is a composer feature; once a v1.0 is
+> tagged, this will no longer be necessary.
 
 ### Basic Usage
 

--- a/composer.json
+++ b/composer.json
@@ -17,10 +17,15 @@
         "laravel/pint": "~1.25.0",
         "mockery/mockery": "^1.4.4",
         "orchestra/testbench": "^10.0",
+        "pestphp/pest": "^4.1",
+        "pestphp/pest-plugin-laravel": "^4.0",
         "phpunit/phpunit": "^11.0|^12.0"
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "pestphp/pest-plugin": true
+        }
     },
     "extra": {
         "laravel": {

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,10 @@
     "keywords": [
         "laravel",
         "cloudflare",
-        "cache"
+        "cache",
+        "cf",
+        "waf",
+        "cdn"
     ],
     "license": "MIT",
     "require": {
@@ -64,7 +67,7 @@
         ],
         "test": [
             "@clear",
-            "@php vendor/bin/phpunit"
+            "@php vendor/bin/pest"
         ]
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "license": "MIT",
     "require": {
-        "php": "^8.2",
+        "php": "^8.3",
         "illuminate/console": "^12.0",
         "illuminate/support": "^12.0"
     },

--- a/src/Commands/BaseCommand.php
+++ b/src/Commands/BaseCommand.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace JTSmith\Cloudflare\Commands;
+
+use Illuminate\Console\Command;
+use JTSmith\Cloudflare\Concerns\ValidatesConfig;
+
+class BaseCommand extends Command
+{
+    use ValidatesConfig;
+}

--- a/src/Commands/GenerateWafRule.php
+++ b/src/Commands/GenerateWafRule.php
@@ -2,22 +2,18 @@
 
 namespace JTSmith\Cloudflare\Commands;
 
-use Illuminate\Console\Command;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Str;
 use JTSmith\Cloudflare\Actions\WafRule;
-use JTSmith\Cloudflare\Concerns\ValidatesConfig;
 use JTSmith\Cloudflare\Exceptions\CloudflareApiException;
 use JTSmith\Cloudflare\Exceptions\CloudflareException;
 use JTSmith\Cloudflare\Exceptions\ConfigValidationException;
 use JTSmith\Cloudflare\Services\Cloudflare\WafRuleService;
 
-class GenerateWafRule extends Command
+class GenerateWafRule extends BaseCommand
 {
-    use ValidatesConfig;
-
     protected $description = 'Generate a Cloudflare security rule for the endpoints available in your application';
 
     protected $signature = 'cloudflare:waf-rule

--- a/src/Commands/PurgeCache.php
+++ b/src/Commands/PurgeCache.php
@@ -2,19 +2,15 @@
 
 namespace JTSmith\Cloudflare\Commands;
 
-use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Str;
-use JTSmith\Cloudflare\Concerns\ValidatesConfig;
 use JTSmith\Cloudflare\Exceptions\CloudflareApiException;
 use JTSmith\Cloudflare\Exceptions\CloudflareException;
 use JTSmith\Cloudflare\Exceptions\ConfigValidationException;
 use JTSmith\Cloudflare\Services\Cloudflare\CachePurgeService;
 
-class PurgeCache extends Command
+class PurgeCache extends BaseCommand
 {
-    use ValidatesConfig;
-
     protected $description = 'Purge Cloudflare cache for specified paths or all content';
 
     protected $signature = 'cloudflare:purge

--- a/src/Commands/PurgeCache.php
+++ b/src/Commands/PurgeCache.php
@@ -5,12 +5,16 @@ namespace JTSmith\Cloudflare\Commands;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Str;
+use JTSmith\Cloudflare\Concerns\ValidatesConfig;
 use JTSmith\Cloudflare\Exceptions\CloudflareApiException;
 use JTSmith\Cloudflare\Exceptions\CloudflareException;
+use JTSmith\Cloudflare\Exceptions\ConfigValidationException;
 use JTSmith\Cloudflare\Services\Cloudflare\CachePurgeService;
 
 class PurgeCache extends Command
 {
+    use ValidatesConfig;
+
     protected $description = 'Purge Cloudflare cache for specified paths or all content';
 
     protected $signature = 'cloudflare:purge
@@ -20,6 +24,12 @@ class PurgeCache extends Command
 
     public function handle(): void
     {
+        try {
+            $this->validateRequiredConfig(['cfcache.api.token', 'cfcache.api.zone_id']);
+        } catch (ConfigValidationException $e) {
+            $this->fail($e->getMessage());
+        }
+
         if ($this->option('all')) {
             if ($this->confirm('Are you sure you want to purge all cached content from Cloudflare?')) {
                 $this->purgeAll();

--- a/src/Concerns/ValidatesConfig.php
+++ b/src/Concerns/ValidatesConfig.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace JTSmith\Cloudflare\Concerns;
+
+use JTSmith\Cloudflare\Exceptions\ConfigValidationException;
+
+trait ValidatesConfig
+{
+    /**
+     * Validate that required configuration keys are set.
+     */
+    protected function validateRequiredConfig(array $requiredKeys): void
+    {
+        foreach ($requiredKeys as $key) {
+            if (! config($key)) {
+                throw new ConfigValidationException("Configuration '{$key}' is required but not set. Please set it in your config or environment variables.");
+            }
+        }
+    }
+}

--- a/src/Exceptions/ConfigValidationException.php
+++ b/src/Exceptions/ConfigValidationException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace JTSmith\Cloudflare\Exceptions;
+
+use RuntimeException;
+
+/**
+ * Exception thrown when required configuration is missing.
+ */
+class ConfigValidationException extends RuntimeException {}

--- a/tests/Feature/Architecture/ArchTest.php
+++ b/tests/Feature/Architecture/ArchTest.php
@@ -1,0 +1,13 @@
+<?php
+
+arch()
+    ->expect('JTSmith\Cloudflare\Commands')
+    ->toExtend('JTSmith\Cloudflare\Commands\BaseCommand');
+
+arch()
+    ->preset()
+    ->laravel();
+
+arch()
+    ->preset()
+    ->security();

--- a/tests/Feature/Commands/GenerateWafRuleTest.php
+++ b/tests/Feature/Commands/GenerateWafRuleTest.php
@@ -9,6 +9,28 @@ use Tests\TestCase;
 
 class GenerateWafRuleTest extends TestCase
 {
+    protected array $validConfig;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->validConfig = [
+            'api' => [
+                'token' => 'test-token-1234567890abcdefghijklmnopqrstuvw',
+                'zone_id' => 'a1b2c3d4e5f678901234567890123456',
+                'settings' => [
+                    'base_url' => 'https://api.cloudflare.com/client/v4',
+                    'timeout' => 30,
+                    'retry_attempts' => 3,
+                    'retry_delay' => 1000,
+                ],
+            ],
+        ];
+
+        Config::set('cfcache', $this->validConfig);
+    }
+
     #[Test]
     public function it_filters_out_ignorable_paths(): void
     {
@@ -52,5 +74,23 @@ class GenerateWafRuleTest extends TestCase
         // Should contain normal routes but not the default ignorable
         $this->assertContains('/', $routes);
         $this->assertNotContains('/_dusk/test', $routes);
+    }
+
+    #[Test]
+    public function it_fails_when_syncing_and_api_token_is_not_set(): void
+    {
+        Config::set('cfcache.api.token', null);
+
+        $this->artisan('cloudflare:waf-rule', ['--sync' => true])
+            ->assertFailed();
+    }
+
+    #[Test]
+    public function it_fails_when_syncing_and_zone_id_is_not_set(): void
+    {
+        Config::set('cfcache.api.zone_id', null);
+
+        $this->artisan('cloudflare:waf-rule', ['--sync' => true])
+            ->assertFailed();
     }
 }

--- a/tests/Feature/Commands/PurgeCacheTest.php
+++ b/tests/Feature/Commands/PurgeCacheTest.php
@@ -203,4 +203,22 @@ class PurgeCacheTest extends TestCase
             ->expectsOutput('HTTP Status: 401')
             ->assertExitCode(0);
     }
+
+    #[Test]
+    public function it_fails_when_api_token_is_not_set(): void
+    {
+        Config::set('cfcache.api.token', null);
+
+        $this->artisan('cloudflare:purge', ['--all' => true])
+            ->assertFailed();
+    }
+
+    #[Test]
+    public function it_fails_when_zone_id_is_not_set(): void
+    {
+        Config::set('cfcache.api.zone_id', null);
+
+        $this->artisan('cloudflare:purge', ['--all' => true])
+            ->assertFailed();
+    }
 }

--- a/tests/Feature/Http/CloudflareApiClientTest.php
+++ b/tests/Feature/Http/CloudflareApiClientTest.php
@@ -17,6 +17,8 @@ class CloudflareApiClientTest extends TestCase
     {
         parent::setUp();
 
+        Http::preventStrayRequests();
+
         $this->client = new CloudflareApiClient(
             'test-token-1234567890',
             'test-zone-id',
@@ -24,7 +26,7 @@ class CloudflareApiClientTest extends TestCase
                 'base_url' => 'https://api.cloudflare.com/client/v4',
                 'timeout' => 30,
                 'retry_attempts' => 3,
-                'retry_delay' => 1000,
+                'retry_delay' => 0,
             ]
         );
     }

--- a/tests/Feature/Services/Cloudflare/CachePurgeServiceTest.php
+++ b/tests/Feature/Services/Cloudflare/CachePurgeServiceTest.php
@@ -25,7 +25,7 @@ class CachePurgeServiceTest extends TestCase
                     'base_url' => 'https://api.cloudflare.com/client/v4',
                     'timeout' => 30,
                     'retry_attempts' => 3,
-                    'retry_delay' => 1000,
+                    'retry_delay' => 0,
                 ],
             ],
         ];

--- a/tests/Feature/Services/Cloudflare/WafRuleServiceTest.php
+++ b/tests/Feature/Services/Cloudflare/WafRuleServiceTest.php
@@ -28,7 +28,7 @@ class WafRuleServiceTest extends TestCase
                     'base_url' => 'https://api.cloudflare.com/client/v4',
                     'timeout' => 30,
                     'retry_attempts' => 3,
-                    'retry_delay' => 1000,
+                    'retry_delay' => 0,
                 ],
             ],
             'features' => [


### PR DESCRIPTION
We should be checking for required configuration options and handling those failures more gracefully.

Here I introduce a trait that should be added to all future commands that can quickly check if the required settings for that specific command are available, and fail if not.