### PR TITLE
Add forced_allowed_paths for WAF rule allowlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ return [
             'rule_description' => env('CFCACHE_RULE_DESCRIPTION', 'Valid Laravel Routes'),
             'rule_action' => env('CFCACHE_RULE_ACTION', 'block'),
             'ignorable_paths' => ['/_dusk/*'],
+            'forced_allowed_paths' => [],
         ],
     ],
 ];
@@ -166,6 +167,22 @@ The patterns support wildcards using Laravel's `Str::is()` syntax:
 
 By default, only `/_dusk/*` is ignored to prevent Dusk testing routes from being
 included in production rules.
+
+#### Forced Allowed Paths
+
+Paths that are not part of your Laravel routes but must be allowed by the WAF
+(e.g. Cloudflare-injected scripts like Zaraz) can be added so they are always
+included in the allowlist:
+
+```php
+'forced_allowed_paths' => [
+    '/cdn-cgi/zaraz/s.js',  // Cloudflare Zaraz
+    '/cdn-cgi/monitor/xhr', // Optional: other edge-injected paths
+],
+```
+
+Wildcards are supported (e.g. `/cdn-cgi/zaraz/*`). Paths are normalized with a
+leading slash if omitted.
 
 ## Cache Purging
 

--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ return [
             'rule_identifier' => env('CFCACHE_RULE_ID', 'laravel-waf-rule'),
             'rule_description' => env('CFCACHE_RULE_DESCRIPTION', 'Valid Laravel Routes'),
             'rule_action' => env('CFCACHE_RULE_ACTION', 'block'),
+            'hostnames' => env('CFCACHE_RULE_HOSTNAMES') ? array_filter(array_map('trim', explode(',', env('CFCACHE_RULE_HOSTNAMES')))) : [],
             'ignorable_paths' => ['/_dusk/*'],
         ],
     ],
@@ -166,6 +167,24 @@ The patterns support wildcards using Laravel's `Str::is()` syntax:
 
 By default, only `/_dusk/*` is ignored to prevent Dusk testing routes from being
 included in production rules.
+
+#### Hostnames
+
+When using multiple hostnames or subdomains in the same zone, you can restrict
+the generated WAF rule so it only applies to specific hosts. If `hostnames` is
+empty (default), the rule applies to all hostnames.
+
+Set hostnames in config or via `.env`:
+
+```php
+// config/cfcache.php — rule applies only when Host matches one of these
+'hostnames' => ['app.example.com', 'www.example.com'],
+```
+
+```env
+# .env — comma-separated
+CFCACHE_RULE_HOSTNAMES=app.example.com,www.example.com
+```
 
 ## Cache Purging
 
@@ -234,11 +253,11 @@ You can create a token with both WAF and Cache Purge permissions if you plan to 
 
 #### Multiple subdomains
 
-If you use multiple subdomains (e.g., `example.com` and `sub.example.com`),
-you will need to add a separate rule for each subdomain, and prefix
-each with `http.host eq "example.com" and ` or
-`http.host eq "sub.example.com" and `
-when generating WAF rules.
+If you use multiple subdomains (e.g., `example.com` and `sub.example.com`) in the
+same zone, set the `hostnames` option in `config/cfcache.php` (see
+[Hostnames](#hostnames)) so the generated WAF rule only
+applies to the hostnames you specify. Otherwise the rule would apply to every
+hostname on the zone.
 
 #### Certbot / .well-known
 

--- a/config/cfcache.php
+++ b/config/cfcache.php
@@ -154,12 +154,12 @@ return [
             | When non-empty, the generated WAF rule only applies when the request
             | hostname matches one of these values (compared against the Host header).
             | When empty, the rule applies to all hostnames (current behavior).
-            | Set as an array here, or use CFCACHE_WAF_HOSTNAMES (comma-separated) in .env.
+            | Set as an array here, or use CFCACHE_RULE_HOSTNAMES (comma-separated) in .env.
             |
             */
 
-            'hostnames' => env('CFCACHE_WAF_HOSTNAMES')
-                ? array_filter(array_map('trim', explode(',', env('CFCACHE_WAF_HOSTNAMES'))))
+            'hostnames' => env('CFCACHE_RULE_HOSTNAMES')
+                ? array_filter(array_map('trim', explode(',', env('CFCACHE_RULE_HOSTNAMES'))))
                 : [],
 
             /*

--- a/config/cfcache.php
+++ b/config/cfcache.php
@@ -148,6 +148,22 @@ return [
 
             /*
             |--------------------------------------------------------------------------
+            | Hostnames
+            |--------------------------------------------------------------------------
+            |
+            | When non-empty, the generated WAF rule only applies when the request
+            | hostname matches one of these values (compared against the Host header).
+            | When empty, the rule applies to all hostnames (current behavior).
+            | Set as an array here, or use CFCACHE_WAF_HOSTNAMES (comma-separated) in .env.
+            |
+            */
+
+            'hostnames' => env('CFCACHE_WAF_HOSTNAMES')
+                ? array_filter(array_map('trim', explode(',', env('CFCACHE_WAF_HOSTNAMES'))))
+                : [],
+
+            /*
+            |--------------------------------------------------------------------------
             | Ignorable Paths
             |--------------------------------------------------------------------------
             |

--- a/config/cfcache.php
+++ b/config/cfcache.php
@@ -158,6 +158,18 @@ return [
             */
 
             'ignorable_paths' => ['/_dusk/*'],
+
+            /*
+            |--------------------------------------------------------------------------
+            | Forced Allowed Paths
+            |--------------------------------------------------------------------------
+            |
+            | Paths that should always be included in the WAF allowlist even though they
+            | are not part of your application routes. Supports wildcards.
+            |
+            */
+
+            'forced_allowed_paths' => [],
         ],
     ],
 ];

--- a/src/Commands/GenerateWafRule.php
+++ b/src/Commands/GenerateWafRule.php
@@ -35,6 +35,12 @@ class GenerateWafRule extends BaseCommand
         $routes = $this->routes($json);
         $rule = $this->generateRule($routes);
 
+        $hostnames = config('cfcache.features.waf.hostnames', []);
+        if (is_array($hostnames) && $hostnames !== []) {
+            $list = implode(' ', array_map(fn (string $h) => '"'.str_replace('"', '\\"', $h).'"', $hostnames));
+            $rule = '(http.host in {'.$list.'}) and ('.$rule.')';
+        }
+
         $this->info('Generated Cloudflare WAF rule:');
         $this->line($rule);
 

--- a/src/Commands/GenerateWafRule.php
+++ b/src/Commands/GenerateWafRule.php
@@ -48,6 +48,7 @@ class GenerateWafRule extends BaseCommand
         $routes = collect(json_decode($json, true))
             ->pluck('uri')
             ->merge($this->publicPaths())
+            ->merge($this->forcedAllowedPaths())
             ->unique()
             ->map(function ($route) {
                 if (! str_contains($route, '{')) {
@@ -105,6 +106,17 @@ class GenerateWafRule extends BaseCommand
         }
 
         return $waf_rule->expression();
+    }
+
+    public function forcedAllowedPaths(): array
+    {
+        $paths = config('cfcache.features.waf.forced_allowed_paths') ?: [];
+
+        return collect($paths)
+            ->map(fn (string $path) => Str::startsWith($path, '/') ? $path : '/'.$path)
+            ->reject(fn (string $path) => $path === '/' || $path === '*')
+            ->values()
+            ->all();
     }
 
     protected function isIgnorablePath(string $route): bool

--- a/tests/Feature/Commands/GenerateWafRuleTest.php
+++ b/tests/Feature/Commands/GenerateWafRuleTest.php
@@ -77,6 +77,24 @@ class GenerateWafRuleTest extends TestCase
     }
 
     #[Test]
+    public function it_includes_forced_allowed_paths_in_the_allowlist(): void
+    {
+        Config::set('cfcache.features.waf.forced_allowed_paths', ['/cdn-cgi/zaraz/s.js', 'cdn-cgi/monitor/xhr']);
+
+        $command = new GenerateWafRule;
+
+        $json = json_encode([
+            ['uri' => '/'],
+        ]);
+
+        $routes = $command->routes($json);
+
+        $this->assertContains('/', $routes);
+        $this->assertContains('/cdn-cgi/zaraz/s.js', $routes);
+        $this->assertContains('/cdn-cgi/monitor/xhr', $routes);
+    }
+
+    #[Test]
     public function it_fails_when_syncing_and_api_token_is_not_set(): void
     {
         Config::set('cfcache.api.token', null);

--- a/tests/Feature/Commands/GenerateWafRuleTest.php
+++ b/tests/Feature/Commands/GenerateWafRuleTest.php
@@ -2,9 +2,11 @@
 
 namespace Tests\Feature\Commands;
 
+use Illuminate\Contracts\Console\Kernel;
 use Illuminate\Support\Facades\Config;
 use JTSmith\Cloudflare\Commands\GenerateWafRule;
 use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Console\Output\BufferedOutput;
 use Tests\TestCase;
 
 class GenerateWafRuleTest extends TestCase
@@ -92,5 +94,29 @@ class GenerateWafRuleTest extends TestCase
 
         $this->artisan('cloudflare:waf-rule', ['--sync' => true])
             ->assertFailed();
+    }
+
+    #[Test]
+    public function it_includes_hostname_condition_in_rule_when_hostnames_configured(): void
+    {
+        Config::set('cfcache.features.waf.hostnames', ['app.example.com', 'www.example.com']);
+
+        $output = new BufferedOutput;
+        $exitCode = $this->app->make(Kernel::class)->call('cloudflare:waf-rule', [], $output);
+
+        $this->assertSame(0, $exitCode);
+        $this->assertStringContainsString('(http.host in {"app.example.com" "www.example.com"}) and (', $output->fetch());
+    }
+
+    #[Test]
+    public function it_omits_hostname_condition_when_hostnames_empty(): void
+    {
+        Config::set('cfcache.features.waf.hostnames', []);
+
+        $output = new BufferedOutput;
+        $exitCode = $this->app->make(Kernel::class)->call('cloudflare:waf-rule', [], $output);
+
+        $this->assertSame(0, $exitCode);
+        $this->assertStringNotContainsString('http.host in {', $output->fetch());
     }
 }

--- a/workbench/config/cfcache.php
+++ b/workbench/config/cfcache.php
@@ -145,6 +145,12 @@ return [
             */
 
             'rule_action' => env('CFCACHE_RULE_ACTION', 'block'),
+
+            'hostnames' => env('CFCACHE_WAF_HOSTNAMES')
+                ? array_filter(array_map('trim', explode(',', env('CFCACHE_WAF_HOSTNAMES'))))
+                : [],
+
+            'ignorable_paths' => ['/_dusk/*'],
         ],
     ],
 ];

--- a/workbench/config/cfcache.php
+++ b/workbench/config/cfcache.php
@@ -146,8 +146,8 @@ return [
 
             'rule_action' => env('CFCACHE_RULE_ACTION', 'block'),
 
-            'hostnames' => env('CFCACHE_WAF_HOSTNAMES')
-                ? array_filter(array_map('trim', explode(',', env('CFCACHE_WAF_HOSTNAMES'))))
+            'hostnames' => env('CFCACHE_RULE_HOSTNAMES')
+                ? array_filter(array_map('trim', explode(',', env('CFCACHE_RULE_HOSTNAMES'))))
                 : [],
 
             'ignorable_paths' => ['/_dusk/*'],


### PR DESCRIPTION
Adds a `forced_allowed_paths` config option so paths that aren’t in the app (e.g. Cloudflare Zaraz `/cdn-cgi/zaraz/s.js`) can be included in the WAF allowlist. Opposite of `ignorable_paths`.