### PR TITLE
feat(waf): add --patch and --check options to waf-rule command

### DIFF
--- a/src/Actions/WafRule.php
+++ b/src/Actions/WafRule.php
@@ -267,6 +267,37 @@ class WafRule
     }
 
     /**
+     * Parse a Cloudflare WAF expression back into a flat collection of paths.
+     *
+     * Handles the two forms emitted by expression():
+     * - Exact paths:    http.request.uri.path in {"/a" "/b"}
+     * - Wildcard paths: http.request.uri.path wildcard "/c/*"
+     *
+     * Examples:
+     * - 'not (http.request.uri.path in {"/about" "/contact"} or http.request.uri.path wildcard "/blog/*")'
+     *   => ["/about", "/contact", "/blog/*"]
+     *
+     * @param  string  $expression  A Cloudflare WAF expression string
+     * @return Collection<int, string>
+     */
+    public function parseExpression(string $expression): Collection
+    {
+        $paths = collect();
+
+        // Extract exact paths from: http.request.uri.path in {"..." "..."}
+        if (preg_match('/http\.request\.uri\.path in \{([^}]+)\}/', $expression, $matches)) {
+            preg_match_all('/"([^"]+)"/', $matches[1], $pathMatches);
+            $paths = $paths->merge($pathMatches[1]);
+        }
+
+        // Extract wildcard paths from: http.request.uri.path wildcard "..."
+        preg_match_all('/http\.request\.uri\.path wildcard "([^"]+)"/', $expression, $wildcardMatches);
+        $paths = $paths->merge($wildcardMatches[1]);
+
+        return $paths->values();
+    }
+
+    /**
      * Build a Cloudflare WAF expression from the given routes (or from $this->routes if omitted).
      *
      * Shape:

--- a/src/Commands/GenerateWafRule.php
+++ b/src/Commands/GenerateWafRule.php
@@ -17,11 +17,17 @@ class GenerateWafRule extends BaseCommand
     protected $description = 'Generate a Cloudflare security rule for the endpoints available in your application';
 
     protected $signature = 'cloudflare:waf-rule
-                            {--sync : Sync the generated rule to Cloudflare via API}';
+                            {--sync : Sync the generated rule to Cloudflare via API}
+                            {--patch : Fetch the existing Cloudflare rule and add only missing paths, preserving all existing ones}
+                            {--check : Compare generated paths against the live Cloudflare rule and report any missing paths}';
 
     public function handle(): void
     {
-        if ($this->option('sync')) {
+        if ($this->option('patch') && $this->option('check')) {
+            $this->warn('--patch and --check cannot be used together. Running --check only.');
+        }
+
+        if ($this->option('sync') || $this->option('patch') || $this->option('check')) {
             try {
                 $this->validateRequiredConfig(['cfcache.api.token', 'cfcache.api.zone_id']);
             } catch (ConfigValidationException $e) {
@@ -33,6 +39,17 @@ class GenerateWafRule extends BaseCommand
         $json = Artisan::output();
 
         $routes = $this->routes($json);
+
+        if ($this->option('check')) {
+            $this->runCheck($routes);
+
+            return;
+        }
+
+        if ($this->option('patch')) {
+            $routes = $this->mergeWithExistingPaths($routes);
+        }
+
         $rule = $this->generateRule($routes);
 
         $this->info('Generated Cloudflare WAF rule:');
@@ -117,6 +134,71 @@ class GenerateWafRule extends BaseCommand
         return collect($ignorable)->contains(function ($pattern) use ($route) {
             return Str::is($pattern, $route);
         });
+    }
+
+    protected function runCheck(Collection $routes): void
+    {
+        $this->newLine();
+        $this->info('Fetching existing WAF rule paths from Cloudflare...');
+
+        try {
+            $service = app(WafRuleService::class);
+            $existingPaths = $service->fetchCurrentPaths();
+
+            if ($existingPaths->isEmpty()) {
+                $this->warn('No existing WAF rule found in Cloudflare. All generated paths would be new.');
+                $this->newLine();
+
+                return;
+            }
+
+            $missing = $routes->diff($existingPaths)->values();
+
+            $this->newLine();
+
+            if ($missing->isEmpty()) {
+                $this->info('All generated paths are already present in the live WAF rule. Nothing to add.');
+
+                return;
+            }
+
+            $this->warn("{$missing->count()} path(s) in your application are missing from the live Cloudflare WAF rule:");
+            $this->newLine();
+            $missing->each(fn ($path) => $this->line("  {$path}"));
+            $this->newLine();
+            $this->comment('Run with --patch --sync to add these paths to the existing rule.');
+        } catch (CloudflareApiException $e) {
+            $this->fail('Could not fetch existing rule: '.$e->getMessage());
+        }
+    }
+
+    protected function mergeWithExistingPaths(Collection $routes): Collection
+    {
+        $this->newLine();
+        $this->info('Fetching existing WAF rule paths from Cloudflare...');
+
+        try {
+            $service = app(WafRuleService::class);
+            $existingPaths = $service->fetchCurrentPaths();
+
+            if ($existingPaths->isEmpty()) {
+                $this->warn('No existing WAF rule found. Generating fresh rule.');
+                $this->newLine();
+
+                return $routes;
+            }
+
+            $this->info("Found {$existingPaths->count()} existing paths in current WAF rule.");
+            $this->newLine();
+
+            return $routes->merge($existingPaths)->unique()->values();
+        } catch (CloudflareApiException $e) {
+            $this->error('Could not fetch existing rule: '.$e->getMessage());
+            $this->warn('Proceeding with freshly generated paths only.');
+            $this->newLine();
+
+            return $routes;
+        }
     }
 
     protected function syncToCloudflare(string $expression): void

--- a/src/Services/Cloudflare/WafRuleService.php
+++ b/src/Services/Cloudflare/WafRuleService.php
@@ -2,6 +2,8 @@
 
 namespace JTSmith\Cloudflare\Services\Cloudflare;
 
+use Illuminate\Support\Collection;
+use JTSmith\Cloudflare\Actions\WafRule;
 use JTSmith\Cloudflare\DTOs\WafRuleResult;
 use JTSmith\Cloudflare\Exceptions\CloudflareApiException;
 use JTSmith\Cloudflare\Http\Clients\WafApiClient;
@@ -30,6 +32,35 @@ class WafRuleService extends CloudflareService
             $this->getZoneId(),
             $this->getHttpOptions()
         );
+    }
+
+    /**
+     * Fetch the paths from the currently deployed WAF rule expression.
+     *
+     * Returns an empty collection when no rule exists or the rule has no expression.
+     * Useful for --patch mode: callers can merge these paths with freshly generated
+     * ones to produce an additive update rather than a full replacement.
+     *
+     * @return Collection<int, string>
+     *
+     * @throws CloudflareApiException If the API request fails
+     */
+    public function fetchCurrentPaths(): Collection
+    {
+        $existingRule = $this->findExistingRule();
+
+        if (! $existingRule) {
+            return collect();
+        }
+
+        $rule = $this->apiClient->getFirewallRule($existingRule['id']);
+        $expression = data_get($rule, 'filter.expression', '');
+
+        if (empty($expression)) {
+            return collect();
+        }
+
+        return (new WafRule)->parseExpression($expression);
     }
 
     /**

--- a/tests/Feature/Actions/WafRuleTest.php
+++ b/tests/Feature/Actions/WafRuleTest.php
@@ -171,4 +171,66 @@ class WafRuleTest extends TestCase
 
         $this->assertEquals($expected, $rule->expression());
     }
+
+    #[Test]
+    public function it_parses_an_expression_with_exact_and_wildcard_paths(): void
+    {
+        $expression = 'not (http.request.uri.path in {"/about" "/contact"} or http.request.uri.path wildcard "/blog/*")';
+
+        $paths = (new WafRule)->parseExpression($expression);
+
+        $this->assertCount(3, $paths);
+        $this->assertContains('/about', $paths);
+        $this->assertContains('/contact', $paths);
+        $this->assertContains('/blog/*', $paths);
+    }
+
+    #[Test]
+    public function it_parses_an_expression_with_only_exact_paths(): void
+    {
+        $expression = 'not (http.request.uri.path in {"/about" "/contact"})';
+
+        $paths = (new WafRule)->parseExpression($expression);
+
+        $this->assertCount(2, $paths);
+        $this->assertContains('/about', $paths);
+        $this->assertContains('/contact', $paths);
+    }
+
+    #[Test]
+    public function it_parses_an_expression_with_only_wildcard_paths(): void
+    {
+        $expression = 'not (http.request.uri.path wildcard "/admin/*" or http.request.uri.path wildcard "/blog/*")';
+
+        $paths = (new WafRule)->parseExpression($expression);
+
+        $this->assertCount(2, $paths);
+        $this->assertContains('/admin/*', $paths);
+        $this->assertContains('/blog/*', $paths);
+    }
+
+    #[Test]
+    public function it_returns_empty_collection_for_empty_expression(): void
+    {
+        $paths = (new WafRule)->parseExpression('');
+
+        $this->assertTrue($paths->isEmpty());
+    }
+
+    #[Test]
+    public function it_round_trips_optimize_and_parse(): void
+    {
+        $original = collect(['/about', '/contact', '/blog/*', '/api/users/*']);
+
+        $rule = new WafRule;
+        $rule->optimize($original);
+        $expression = $rule->expression();
+
+        $parsed = (new WafRule)->parseExpression($expression);
+
+        $this->assertContains('/about', $parsed);
+        $this->assertContains('/contact', $parsed);
+        $this->assertContains('/blog/*', $parsed);
+        $this->assertContains('/api/users/*', $parsed);
+    }
 }

--- a/tests/Feature/Commands/GenerateWafRuleTest.php
+++ b/tests/Feature/Commands/GenerateWafRuleTest.php
@@ -4,12 +4,22 @@ namespace Tests\Feature\Commands;
 
 use Illuminate\Support\Facades\Config;
 use JTSmith\Cloudflare\Commands\GenerateWafRule;
+use JTSmith\Cloudflare\DTOs\WafRuleResult;
+use JTSmith\Cloudflare\Exceptions\CloudflareApiException;
+use JTSmith\Cloudflare\Services\Cloudflare\WafRuleService;
+use Mockery;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
 class GenerateWafRuleTest extends TestCase
 {
     protected array $validConfig;
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
 
     protected function setUp(): void
     {
@@ -92,5 +102,229 @@ class GenerateWafRuleTest extends TestCase
 
         $this->artisan('cloudflare:waf-rule', ['--sync' => true])
             ->assertFailed();
+    }
+
+    // --patch tests
+
+    #[Test]
+    public function it_fails_when_patching_and_api_token_is_not_set(): void
+    {
+        Config::set('cfcache.api.token', null);
+
+        $this->artisan('cloudflare:waf-rule', ['--patch' => true])
+            ->assertFailed();
+    }
+
+    #[Test]
+    public function it_fails_when_patching_and_zone_id_is_not_set(): void
+    {
+        Config::set('cfcache.api.zone_id', null);
+
+        $this->artisan('cloudflare:waf-rule', ['--patch' => true])
+            ->assertFailed();
+    }
+
+    #[Test]
+    public function it_merges_existing_paths_when_patch_flag_is_used(): void
+    {
+        $mockService = Mockery::mock(WafRuleService::class);
+        $mockService->shouldReceive('fetchCurrentPaths')
+            ->once()
+            ->andReturn(collect(['/existing-path', '/legacy/*']));
+
+        $this->app->instance(WafRuleService::class, $mockService);
+
+        $this->artisan('cloudflare:waf-rule', ['--patch' => true])
+            ->expectsOutputToContain('Fetching existing WAF rule paths from Cloudflare')
+            ->expectsOutputToContain('Found 2 existing paths in current WAF rule')
+            ->assertSuccessful();
+    }
+
+    #[Test]
+    public function it_warns_and_continues_when_patch_finds_no_existing_rule(): void
+    {
+        $mockService = Mockery::mock(WafRuleService::class);
+        $mockService->shouldReceive('fetchCurrentPaths')
+            ->once()
+            ->andReturn(collect());
+
+        $this->app->instance(WafRuleService::class, $mockService);
+
+        $this->artisan('cloudflare:waf-rule', ['--patch' => true])
+            ->expectsOutputToContain('No existing WAF rule found')
+            ->assertSuccessful();
+    }
+
+    #[Test]
+    public function it_continues_with_fresh_paths_when_patch_api_call_fails(): void
+    {
+        $mockService = Mockery::mock(WafRuleService::class);
+        $mockService->shouldReceive('fetchCurrentPaths')
+            ->once()
+            ->andThrow(new CloudflareApiException(
+                'Authentication failed',
+                401,
+                null,
+                401,
+                [],
+                'zones/zone_id/firewall/rules',
+                'GET'
+            ));
+
+        $this->app->instance(WafRuleService::class, $mockService);
+
+        $this->artisan('cloudflare:waf-rule', ['--patch' => true])
+            ->expectsOutputToContain('Could not fetch existing rule')
+            ->assertSuccessful();
+    }
+
+    // --check tests
+
+    #[Test]
+    public function it_fails_when_checking_and_api_token_is_not_set(): void
+    {
+        Config::set('cfcache.api.token', null);
+
+        $this->artisan('cloudflare:waf-rule', ['--check' => true])
+            ->assertFailed();
+    }
+
+    #[Test]
+    public function it_fails_when_checking_and_zone_id_is_not_set(): void
+    {
+        Config::set('cfcache.api.zone_id', null);
+
+        $this->artisan('cloudflare:waf-rule', ['--check' => true])
+            ->assertFailed();
+    }
+
+    #[Test]
+    public function it_reports_missing_paths_when_checking_against_live_rule(): void
+    {
+        $mockService = Mockery::mock(WafRuleService::class);
+        $mockService->shouldReceive('fetchCurrentPaths')
+            ->once()
+            ->andReturn(collect(['/about', '/contact']));
+
+        $this->app->instance(WafRuleService::class, $mockService);
+
+        $this->artisan('cloudflare:waf-rule', ['--check' => true])
+            ->expectsOutputToContain('Fetching existing WAF rule paths from Cloudflare')
+            ->expectsOutputToContain('path(s) in your application are missing from the live Cloudflare WAF rule')
+            ->assertSuccessful();
+    }
+
+    #[Test]
+    public function it_reports_all_paths_present_when_nothing_is_missing(): void
+    {
+        // Suppress all testbench-specific routes/files so routes() returns empty.
+        // An empty diff against any non-empty existing set → "all present" message.
+        Config::set('cfcache.features.waf.ignorable_paths', ['/_dusk/*', '/_workbench/*', '/.gitignore']);
+
+        $mockService = Mockery::mock(WafRuleService::class);
+        $mockService->shouldReceive('fetchCurrentPaths')
+            ->once()
+            ->andReturn(collect(['/about', '/contact']));
+
+        $this->app->instance(WafRuleService::class, $mockService);
+
+        $this->artisan('cloudflare:waf-rule', ['--check' => true])
+            ->expectsOutputToContain('All generated paths are already present')
+            ->assertSuccessful();
+    }
+
+    #[Test]
+    public function it_warns_when_check_finds_no_existing_rule(): void
+    {
+        $mockService = Mockery::mock(WafRuleService::class);
+        $mockService->shouldReceive('fetchCurrentPaths')
+            ->once()
+            ->andReturn(collect());
+
+        $this->app->instance(WafRuleService::class, $mockService);
+
+        $this->artisan('cloudflare:waf-rule', ['--check' => true])
+            ->expectsOutputToContain('No existing WAF rule found in Cloudflare')
+            ->assertSuccessful();
+    }
+
+    #[Test]
+    public function it_does_not_output_the_expression_when_check_flag_is_used(): void
+    {
+        $mockService = Mockery::mock(WafRuleService::class);
+        $mockService->shouldReceive('fetchCurrentPaths')
+            ->once()
+            ->andReturn(collect(['/about']));
+
+        $this->app->instance(WafRuleService::class, $mockService);
+
+        $this->artisan('cloudflare:waf-rule', ['--check' => true])
+            ->doesntExpectOutputToContain('Generated Cloudflare WAF rule')
+            ->assertSuccessful();
+    }
+
+    #[Test]
+    public function it_fails_when_check_api_call_fails(): void
+    {
+        $mockService = Mockery::mock(WafRuleService::class);
+        $mockService->shouldReceive('fetchCurrentPaths')
+            ->once()
+            ->andThrow(new CloudflareApiException(
+                'Unauthorized',
+                401,
+                null,
+                401,
+                [],
+                'zones/zone_id/firewall/rules',
+                'GET'
+            ));
+
+        $this->app->instance(WafRuleService::class, $mockService);
+
+        $this->artisan('cloudflare:waf-rule', ['--check' => true])
+            ->expectsOutputToContain('Could not fetch existing rule')
+            ->assertFailed();
+    }
+
+    #[Test]
+    public function it_warns_when_patch_and_check_are_used_together(): void
+    {
+        $mockService = Mockery::mock(WafRuleService::class);
+        $mockService->shouldReceive('fetchCurrentPaths')
+            ->once()
+            ->andReturn(collect(['/about']));
+
+        $this->app->instance(WafRuleService::class, $mockService);
+
+        $this->artisan('cloudflare:waf-rule', ['--patch' => true, '--check' => true])
+            ->expectsOutputToContain('--patch and --check cannot be used together')
+            ->assertSuccessful();
+    }
+
+    #[Test]
+    public function it_merges_and_syncs_when_patch_and_sync_are_used_together(): void
+    {
+        $mockService = Mockery::mock(WafRuleService::class);
+        $mockService->shouldReceive('fetchCurrentPaths')
+            ->once()
+            ->andReturn(collect(['/existing-path']));
+
+        $mockService->shouldReceive('syncRule')
+            ->once()
+            ->andReturn(new WafRuleResult(
+                action: 'Updated',
+                ruleId: 'rule-123',
+                filterId: 'filter-456',
+                expression: '',
+                message: 'WAF rule updated successfully',
+            ));
+
+        $this->app->instance(WafRuleService::class, $mockService);
+
+        $this->artisan('cloudflare:waf-rule', ['--patch' => true, '--sync' => true])
+            ->expectsOutputToContain('Fetching existing WAF rule paths from Cloudflare')
+            ->expectsOutputToContain('Found 1 existing paths in current WAF rule')
+            ->expectsOutputToContain('Syncing WAF rule to Cloudflare')
+            ->assertSuccessful();
     }
 }

--- a/tests/Feature/Services/Cloudflare/WafRuleServiceTest.php
+++ b/tests/Feature/Services/Cloudflare/WafRuleServiceTest.php
@@ -352,6 +352,88 @@ class WafRuleServiceTest extends TestCase
     }
 
     #[Test]
+    public function it_fetches_current_paths_from_an_existing_rule(): void
+    {
+        $mockClient = Mockery::mock(WafApiClient::class);
+
+        $mockClient->shouldReceive('getFirewallRules')
+            ->once()
+            ->andReturn([
+                [
+                    'id' => 'existing-rule-123',
+                    'description' => 'Test WAF Rule [id:test-rule]',
+                    'filter' => ['id' => 'existing-filter-123'],
+                ],
+            ]);
+
+        $mockClient->shouldReceive('getFirewallRule')
+            ->once()
+            ->with('existing-rule-123')
+            ->andReturn([
+                'id' => 'existing-rule-123',
+                'filter' => [
+                    'id' => 'existing-filter-123',
+                    'expression' => 'not (http.request.uri.path in {"/about" "/contact"} or http.request.uri.path wildcard "/blog/*")',
+                ],
+            ]);
+
+        $service = new WafRuleService($this->validConfig, $mockClient);
+        $paths = $service->fetchCurrentPaths();
+
+        $this->assertCount(3, $paths);
+        $this->assertContains('/about', $paths);
+        $this->assertContains('/contact', $paths);
+        $this->assertContains('/blog/*', $paths);
+    }
+
+    #[Test]
+    public function it_returns_empty_collection_when_no_existing_rule_is_found(): void
+    {
+        $mockClient = Mockery::mock(WafApiClient::class);
+
+        $mockClient->shouldReceive('getFirewallRules')
+            ->once()
+            ->andReturn([]);
+
+        $service = new WafRuleService($this->validConfig, $mockClient);
+        $paths = $service->fetchCurrentPaths();
+
+        $this->assertTrue($paths->isEmpty());
+    }
+
+    #[Test]
+    public function it_returns_empty_collection_when_existing_rule_has_no_expression(): void
+    {
+        $mockClient = Mockery::mock(WafApiClient::class);
+
+        $mockClient->shouldReceive('getFirewallRules')
+            ->once()
+            ->andReturn([
+                [
+                    'id' => 'existing-rule-123',
+                    'description' => 'Test WAF Rule [id:test-rule]',
+                    'filter' => ['id' => 'existing-filter-123'],
+                ],
+            ]);
+
+        $mockClient->shouldReceive('getFirewallRule')
+            ->once()
+            ->with('existing-rule-123')
+            ->andReturn([
+                'id' => 'existing-rule-123',
+                'filter' => [
+                    'id' => 'existing-filter-123',
+                    'expression' => '',
+                ],
+            ]);
+
+        $service = new WafRuleService($this->validConfig, $mockClient);
+        $paths = $service->fetchCurrentPaths();
+
+        $this->assertTrue($paths->isEmpty());
+    }
+
+    #[Test]
     public function it_contains_endpoint_and_method_information(): void
     {
         Http::fake([


### PR DESCRIPTION
  - Add --patch to merge freshly generated paths with the live Cloudflare rule (additive update)
  - Add --check for a read-only diff report of app routes missing from the live rule
  - Add WafRule::parseExpression() to reverse-parse Cloudflare expressions back to paths
  - Add WafRuleService::fetchCurrentPaths() to retrieve and parse the deployed rule
  - Guard against --patch --check used together; --check API failures now exit non-zero
  - Add 22 tests covering patch, check, parse, and service fetch behaviour