### PR TITLE
feat: adds support for Windows environments

### DIFF
--- a/src/Commands/GenerateWafRule.php
+++ b/src/Commands/GenerateWafRule.php
@@ -75,6 +75,7 @@ class GenerateWafRule extends BaseCommand
         $glob = File::glob(base_path('public/{,.}*'), GLOB_BRACE);
 
         return collect($glob)
+            ->map(fn ($path) => Str::replace('\\', '/', $path))
             ->map(fn ($path) => Str::after($path, '/public/'))
             ->reject(fn ($path) => in_array($path, ['.', '..', '.htaccess', 'index.php']))
             ->map(fn ($path) => File::isDirectory(public_path($path)) ? $path.'/*' : $path)

--- a/tests/Feature/Commands/GenerateWafRuleTest.php
+++ b/tests/Feature/Commands/GenerateWafRuleTest.php
@@ -32,6 +32,31 @@ class GenerateWafRuleTest extends TestCase
     }
 
     #[Test]
+    public function it_prevents_routes_doesnt_contain_windows_absolute_paths()
+    {
+        $command = new GenerateWafRule;
+
+        $json = json_encode([
+            ['uri' => '/'],
+            ['uri' => 'about'],
+            ['uri' => 'api/users'],
+        ]);
+
+        $routes = $command->routes($json);
+
+        $this->assertContains('/', $routes);
+        $this->assertContains('/about', $routes);
+        $this->assertContains('/api/users', $routes);
+
+        // Assert no Windows absolute paths leaked in
+        $windowsPaths = $routes->filter(fn (string $r) => preg_match('#^/[A-Za-z]:\\\\#', $r));
+        $this->assertEmpty(
+            $windowsPaths->all(),
+            'Routes should not contain Windows absolute paths, but found: '.$windowsPaths->implode(', ')
+        );
+    }
+
+    #[Test]
     public function it_filters_out_ignorable_paths(): void
     {
         Config::set('cfcache.features.waf.ignorable_paths', ['/_dusk/*', '/admin/test']);


### PR DESCRIPTION
If the `GenerateWafRule` command is run in a Windows environment, the `$routes` array gets populated with Windows absolute paths by the `publicPaths` method.

Before:

```php
[
  "/",
  "/about",
  "/api/users",
  "/C:\Users\Sergio\Herd\laravel-cfcache\vendor\orchestra\testbench-core\laravel\public/index.php",
  "/C:\Users\Sergio\Herd\laravel-cfcache\vendor\orchestra\testbench-core\laravel\public/.",
  "/C:\Users\Sergio\Herd\laravel-cfcache\vendor\orchestra\testbench-core\laravel\public/..",
  "/C:\Users\Sergio\Herd\laravel-cfcache\vendor\orchestra\testbench-core\laravel\public/.gitignore",
]
```

This PR adds a new `map` to convert backslashes (Windows path style) to forward slashes, so the next `map` can trim the absolute path.

After:

```php
[
  "/",
  "/about",
  "/api/users",
  "/.gitignore",
]
```

I've also added a new test to ensure that no Windows absolute paths are leaked.