### PR TITLE
feat: allow future scheduling of cache purging

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ php artisan cloudflare:purge / /about https://example.com/faq https://example.co
 
 # Purge by route names
 php artisan cloudflare:purge --route=home --route=users.index --route=auth.login
+
+# Schedule a purge for later
+php artisan cloudflare:purge /about --schedule="2026-06-03 10:00:00"
+php artisan cloudflare:purge --route=home --schedule="tomorrow 02:00"
 ```
 
 Please see the [Notes](#notes) section below for additional information and
@@ -124,6 +128,10 @@ return [
             'retry_attempts' => env('CFCACHE_API_RETRY_ATTEMPTS', 3),
             'retry_delay' => env('CFCACHE_API_RETRY_DELAY', 1000),
         ],
+    ],
+
+    'scheduled_purges' => [
+        'file' => env('CFCACHE_SCHEDULED_PURGES_FILE', storage_path('app/laravel-cfcache/scheduled-purges.json')),
     ],
 
     'features' => [
@@ -255,6 +263,45 @@ php artisan cloudflare:purge --routes=home --routes=about --routes=users.show
 
 # Combine routes and paths
 php artisan cloudflare:purge /blog --routes=contact --routes=api.users.index
+```
+
+### Scheduled Cache Purges
+
+Add `--schedule` with any timestamp Carbon can parse to store a purge for later:
+
+```sh
+# Schedule specific paths
+php artisan cloudflare:purge /about /contact --schedule="2026-06-03 10:00:00"
+
+# Schedule route-based purges
+php artisan cloudflare:purge --route=home --route=users.index --schedule="tomorrow 02:00"
+
+# Schedule a full cache purge
+php artisan cloudflare:purge --all --force --schedule="2026-06-03 10:00:00"
+```
+
+Scheduled purges are stored on disk at the path configured by
+`cfcache.scheduled_purges.file`, which defaults to
+`storage/app/laravel-cfcache/scheduled-purges.json`. The stored command
+parameters do not include `--schedule`, so due purges are re-run as normal
+`cloudflare:purge` commands.
+
+> [!NOTE]
+> This package does *NOT* automatically register a Laravel scheduled task. You must
+> opt in by adding one to your application. This is intentional because scheduled
+> tasks can have a financial impact on hosting providers such as
+> [Laravel Cloud](https://cloud.laravel.com/docs/scheduled-tasks).
+
+Add this to your `routes/console.php`:
+
+```php
+use Illuminate\Support\Facades\Schedule;
+use JTSmith\Cloudflare\Support\ScheduledPurgeStore;
+
+Schedule::call(fn (ScheduledPurgeStore $store) => $store->runDue())
+    ->name('cloudflare-scheduled-cache-purges')
+    ->everyMinute()
+    ->withoutOverlapping();
 ```
 
 ### Cloudflare API Configuration for Cache Purging

--- a/config/cfcache.php
+++ b/config/cfcache.php
@@ -96,6 +96,21 @@ return [
         ],
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Scheduled Purges
+    |--------------------------------------------------------------------------
+    |
+    | Scheduled purge requests are stored on disk until your application's
+    | scheduler runs them. You may customize this path if the default storage
+    | location does not work for your deployment environment.
+    |
+    */
+
+    'scheduled_purges' => [
+        'file' => env('CFCACHE_SCHEDULED_PURGES_FILE', storage_path('app/laravel-cfcache/scheduled-purges.json')),
+    ],
+
     'features' => [
 
         /*

--- a/src/Commands/PurgeCache.php
+++ b/src/Commands/PurgeCache.php
@@ -2,12 +2,15 @@
 
 namespace JTSmith\Cloudflare\Commands;
 
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Str;
 use JTSmith\Cloudflare\Exceptions\CloudflareApiException;
 use JTSmith\Cloudflare\Exceptions\CloudflareException;
 use JTSmith\Cloudflare\Exceptions\ConfigValidationException;
 use JTSmith\Cloudflare\Services\Cloudflare\CachePurgeService;
+use JTSmith\Cloudflare\Support\ScheduledPurgeStore;
+use Throwable;
 
 class PurgeCache extends BaseCommand
 {
@@ -16,6 +19,7 @@ class PurgeCache extends BaseCommand
     protected $signature = 'cloudflare:purge
                             {paths?* : Paths to purge (relative or full URLs). If omitted, purges all cache}
                             {--route=* : Route names to resolve and purge}
+                            {--schedule= : Schedule the purge for a timestamp parseable by Carbon}
                             {--force : Do not prompt for confirmation when purging cache}
                             {--all : Purge all cached content from Cloudflare}';
 
@@ -25,6 +29,12 @@ class PurgeCache extends BaseCommand
             $this->validateRequiredConfig(['cfcache.api.token', 'cfcache.api.zone_id']);
         } catch (ConfigValidationException $e) {
             $this->fail($e->getMessage());
+        }
+
+        if ($this->option('schedule')) {
+            $this->schedulePurge($this->option('schedule'));
+
+            return;
         }
 
         if ($this->option('all')) {
@@ -53,6 +63,37 @@ class PurgeCache extends BaseCommand
         }
         $this->newLine();
         $this->purgePaths($paths->all());
+    }
+
+    protected function schedulePurge(string $timestamp): void
+    {
+        if (! $this->option('all') && empty($this->argument('paths')) && empty($this->option('route'))) {
+            $this->warn('You must specify at least one path or route to purge. Or purge everything with `--all`.');
+
+            return;
+        }
+
+        if ($this->option('all') && ! $this->option('force') && ! $this->confirm('Are you sure you want to purge all cached content from Cloudflare?')) {
+
+            return;
+        }
+
+        try {
+            $runAt = Carbon::parse($timestamp);
+        } catch (Throwable) {
+            $this->error("Unable to parse schedule timestamp: {$timestamp}");
+
+            return;
+        }
+
+        app(ScheduledPurgeStore::class)->add($runAt, $this->getName(), [
+            'paths' => $this->argument('paths'),
+            '--route' => $this->option('route'),
+            '--force' => (bool) $this->option('force'),
+            '--all' => (bool) $this->option('all'),
+        ]);
+
+        $this->info('Cloudflare cache purge scheduled for '.$runAt->toDateTimeString().'.');
     }
 
     public function resolveRoutes(array $routeNames): array

--- a/src/PageCacheServiceProvider.php
+++ b/src/PageCacheServiceProvider.php
@@ -2,14 +2,14 @@
 
 namespace JTSmith\Cloudflare;
 
-use Illuminate\Contracts\Support\DeferrableProvider;
 use Illuminate\Support\ServiceProvider;
 use JTSmith\Cloudflare\Commands\GenerateWafRule;
 use JTSmith\Cloudflare\Commands\PurgeCache;
 use JTSmith\Cloudflare\Services\Cloudflare\CachePurgeService;
 use JTSmith\Cloudflare\Services\Cloudflare\WafRuleService;
+use JTSmith\Cloudflare\Support\ScheduledPurgeStore;
 
-class PageCacheServiceProvider extends ServiceProvider implements DeferrableProvider
+class PageCacheServiceProvider extends ServiceProvider
 {
     /**
      * Bootstrap the application events.
@@ -49,6 +49,8 @@ class PageCacheServiceProvider extends ServiceProvider implements DeferrableProv
         $this->app->singleton(CachePurgeService::class, function ($app) {
             return new CachePurgeService($app['config']->get('cfcache', []));
         });
+
+        $this->app->singleton(ScheduledPurgeStore::class);
     }
 
     /**
@@ -60,6 +62,7 @@ class PageCacheServiceProvider extends ServiceProvider implements DeferrableProv
             CachePurgeService::class,
             GenerateWafRule::class,
             PurgeCache::class,
+            ScheduledPurgeStore::class,
             WafRuleService::class,
         ];
     }

--- a/src/Support/ScheduledPurgeStore.php
+++ b/src/Support/ScheduledPurgeStore.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace JTSmith\Cloudflare\Support;
+
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+
+class ScheduledPurgeStore
+{
+    public function all(): array
+    {
+        if (! File::exists($this->path())) {
+            return [];
+        }
+
+        $entries = json_decode(File::get($this->path()), true);
+
+        return is_array($entries) ? $entries : [];
+    }
+
+    public function add(Carbon $runAt, string $command, array $parameters): void
+    {
+        $entries = $this->all();
+
+        $entries[] = [
+            'run_at' => $runAt->toIso8601String(),
+            'command' => $command,
+            'parameters' => $parameters,
+        ];
+
+        $this->write($entries);
+    }
+
+    public function due(Carbon $now): array
+    {
+        return array_values(array_filter(
+            $this->all(),
+            fn (array $entry): bool => Carbon::parse($entry['run_at'])->lte($now)
+        ));
+    }
+
+    public function remove(array $entryToRemove): void
+    {
+        $entries = array_values(array_filter(
+            $this->all(),
+            fn (array $entry): bool => $entry !== $entryToRemove
+        ));
+
+        $this->write($entries);
+    }
+
+    public function runDue(?Carbon $now = null): void
+    {
+        foreach ($this->due($now ?? Carbon::now()) as $entry) {
+            Artisan::call($entry['command'], $entry['parameters'] ?? []);
+
+            $this->remove($entry);
+        }
+    }
+
+    public function path(): string
+    {
+        return config('cfcache.scheduled_purges.file', storage_path('app/laravel-cfcache/scheduled-purges.json'));
+    }
+
+    protected function write(array $entries): void
+    {
+        File::ensureDirectoryExists(dirname($this->path()));
+        File::put($this->path(), json_encode($entries, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+    }
+}

--- a/tests/Feature/Commands/PurgeCacheTest.php
+++ b/tests/Feature/Commands/PurgeCacheTest.php
@@ -2,12 +2,15 @@
 
 namespace Tests\Feature\Commands;
 
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Route;
 use JTSmith\Cloudflare\Commands\PurgeCache;
 use JTSmith\Cloudflare\Exceptions\CloudflareApiException;
 use JTSmith\Cloudflare\Services\Cloudflare\CachePurgeService;
+use JTSmith\Cloudflare\Support\ScheduledPurgeStore;
 use Mockery;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
@@ -35,11 +38,15 @@ class PurgeCacheTest extends TestCase
 
         Config::set('cfcache', $this->validConfig);
         Config::set('app.url', 'https://example.com');
+
+        File::delete(app(ScheduledPurgeStore::class)->path());
     }
 
     protected function tearDown(): void
     {
         Mockery::close();
+        File::delete(app(ScheduledPurgeStore::class)->path());
+
         parent::tearDown();
     }
 
@@ -123,6 +130,144 @@ class PurgeCacheTest extends TestCase
                 && isset($data['files'])
                 && $data['files'] === ['https://example.com/', 'https://example.com/about'];
         });
+    }
+
+    #[Test]
+    public function it_schedules_a_purge_without_calling_cloudflare(): void
+    {
+        Http::fake([
+            '*/purge_cache' => Http::response(['success' => true]),
+        ]);
+
+        $this->artisan('cloudflare:purge', [
+            'paths' => ['about'],
+            '--route' => ['home'],
+            '--schedule' => '2026-06-03 10:00:00',
+        ])
+            ->expectsOutput('Cloudflare cache purge scheduled for 2026-06-03 10:00:00.')
+            ->assertExitCode(0);
+
+        $entries = app(ScheduledPurgeStore::class)->all();
+
+        $this->assertCount(1, $entries);
+        $this->assertSame('cloudflare:purge', $entries[0]['command']);
+        $this->assertSame(['about'], $entries[0]['parameters']['paths']);
+        $this->assertSame(['home'], $entries[0]['parameters']['--route']);
+        $this->assertArrayNotHasKey('--schedule', $entries[0]['parameters']);
+
+        Http::assertNothingSent();
+    }
+
+    #[Test]
+    public function it_confirms_before_scheduling_a_full_cache_purge(): void
+    {
+        $this->artisan('cloudflare:purge', [
+            '--all' => true,
+            '--schedule' => '2026-06-03 10:00:00',
+        ])
+            ->expectsConfirmation('Are you sure you want to purge all cached content from Cloudflare?', 'yes')
+            ->expectsOutput('Cloudflare cache purge scheduled for 2026-06-03 10:00:00.')
+            ->assertExitCode(0);
+
+        $entries = app(ScheduledPurgeStore::class)->all();
+
+        $this->assertCount(1, $entries);
+        $this->assertTrue($entries[0]['parameters']['--all']);
+        $this->assertFalse($entries[0]['parameters']['--force']);
+    }
+
+    #[Test]
+    public function it_does_not_confirm_before_scheduling_a_forced_full_cache_purge(): void
+    {
+        $this->artisan('cloudflare:purge', [
+            '--all' => true,
+            '--force' => true,
+            '--schedule' => '2026-06-03 10:00:00',
+        ])
+            ->expectsOutput('Cloudflare cache purge scheduled for 2026-06-03 10:00:00.')
+            ->assertExitCode(0);
+
+        $entries = app(ScheduledPurgeStore::class)->all();
+
+        $this->assertCount(1, $entries);
+        $this->assertTrue($entries[0]['parameters']['--all']);
+        $this->assertTrue($entries[0]['parameters']['--force']);
+    }
+
+    #[Test]
+    public function it_does_not_schedule_a_full_cache_purge_when_confirmation_is_declined(): void
+    {
+        $this->artisan('cloudflare:purge', [
+            '--all' => true,
+            '--schedule' => '2026-06-03 10:00:00',
+        ])
+            ->expectsConfirmation('Are you sure you want to purge all cached content from Cloudflare?', 'no')
+            ->assertExitCode(0);
+
+        $this->assertSame([], app(ScheduledPurgeStore::class)->all());
+    }
+
+    #[Test]
+    public function it_uses_the_configured_scheduled_purge_file(): void
+    {
+        $path = storage_path('framework/testing/custom-scheduled-purges.json');
+
+        Config::set('cfcache.scheduled_purges.file', $path);
+        File::delete($path);
+
+        $this->artisan('cloudflare:purge', [
+            'paths' => ['about'],
+            '--schedule' => '2026-06-03 10:00:00',
+        ])
+            ->expectsOutput('Cloudflare cache purge scheduled for 2026-06-03 10:00:00.')
+            ->assertExitCode(0);
+
+        $this->assertFileExists($path);
+
+        File::delete($path);
+    }
+
+    #[Test]
+    public function it_does_not_schedule_a_purge_when_api_token_is_not_set(): void
+    {
+        Config::set('cfcache.api.token', null);
+
+        $this->artisan('cloudflare:purge', [
+            'paths' => ['about'],
+            '--schedule' => '2026-06-03 10:00:00',
+        ])
+            ->assertFailed();
+
+        $this->assertSame([], app(ScheduledPurgeStore::class)->all());
+    }
+
+    #[Test]
+    public function it_runs_and_removes_due_scheduled_purges(): void
+    {
+        app(ScheduledPurgeStore::class)->add(Carbon::now()->subMinute(), 'cloudflare:purge', [
+            'paths' => ['about'],
+            '--route' => [],
+            '--force' => false,
+            '--all' => false,
+        ]);
+
+        Http::fake([
+            '*/purge_cache' => Http::response([
+                'success' => true,
+                'result' => ['id' => 'scheduled-purge-123'],
+            ]),
+        ]);
+
+        app(ScheduledPurgeStore::class)->runDue();
+
+        Http::assertSent(function ($request) {
+            $data = $request->data();
+
+            return str_contains($request->url(), 'purge_cache')
+                && $data['files'] === ['https://example.com/about'];
+        });
+
+        $this->assertSame([], app(ScheduledPurgeStore::class)->all());
     }
 
     #[Test]

--- a/workbench/config/cfcache.php
+++ b/workbench/config/cfcache.php
@@ -96,6 +96,10 @@ return [
         ],
     ],
 
+    'scheduled_purges' => [
+        'file' => env('CFCACHE_SCHEDULED_PURGES_FILE', storage_path('app/laravel-cfcache/scheduled-purges.json')),
+    ],
+
     'features' => [
 
         /*


### PR DESCRIPTION
This PR adds support for scheduling Cloudflare cache purges via a new `--schedule` option on `cloudflare:purge`. Scheduled purges are stored on disk with the original purge command parameters, excluding `--schedule`, and can later be executed by calling `ScheduledPurgeStore::runDue()` from the application scheduler. The storage path is configurable via `cfcache.scheduled_purges.file`, defaulting to `storage/app/laravel-cfcache/scheduled-purges.json`.

This intentionally does *NOT* auto-register a Laravel scheduled task, since scheduled tasks can have hosting cost implications on services like Laravel Cloud. The README now documents scheduling usage, the manual scheduler setup, and the Laravel Cloud caveat. Scheduled full-cache purges still require confirmation unless `--force` is provided, matching the existing immediate purge behavior.