### PR TITLE
feat: support `--prefix` and `--host` flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ php artisan cloudflare:purge / /about https://example.com/faq https://example.co
 php artisan cloudflare:purge --route=home --route=users.index --route=auth.login
 
 # Purge everything under one or more URL prefixes
-php artisan cloudflare:purge --prefix=https://www.example.com/
+php artisan cloudflare:purge --prefix=www.example.com/
 
 # Purge everything cached for one or more hosts
 php artisan cloudflare:purge --host=www.example.com
@@ -277,10 +277,10 @@ Use `--prefix` when you want to purge every cached URL under a specific prefix w
 
 ```sh
 # Purge the marketing site only
-php artisan cloudflare:purge --prefix=https://www.example.com/
+php artisan cloudflare:purge --prefix=www.example.com/
 
 # Purge multiple URL prefixes
-php artisan cloudflare:purge --prefix=https://www.example.com/blog/ --prefix=https://www.example.com/docs/
+php artisan cloudflare:purge --prefix=www.example.com/blog/ --prefix=www.example.com/docs/
 ```
 
 Use `--host` when you want to purge everything cached for a host:
@@ -310,7 +310,7 @@ php artisan cloudflare:purge --route=home --route=users.index --schedule="tomorr
 php artisan cloudflare:purge --all --force --schedule="2026-06-03 10:00:00"
 
 # Schedule a prefix purge
-php artisan cloudflare:purge --prefix=https://www.example.com/ --schedule="2026-06-03 10:00:00"
+php artisan cloudflare:purge --prefix=www.example.com/ --schedule="2026-06-03 10:00:00"
 ```
 
 Scheduled purges are stored on disk at the path configured by

--- a/README.md
+++ b/README.md
@@ -62,6 +62,12 @@ php artisan cloudflare:purge / /about https://example.com/faq https://example.co
 # Purge by route names
 php artisan cloudflare:purge --route=home --route=users.index --route=auth.login
 
+# Purge everything under one or more URL prefixes
+php artisan cloudflare:purge --prefix=https://www.example.com/
+
+# Purge everything cached for one or more hosts
+php artisan cloudflare:purge --host=www.example.com
+
 # Schedule a purge for later
 php artisan cloudflare:purge /about --schedule="2026-06-03 10:00:00"
 php artisan cloudflare:purge --route=home --schedule="tomorrow 02:00"
@@ -259,11 +265,35 @@ Purge cache for specific Laravel routes by name (route parameters are converted 
 
 ```sh
 # Purge by route names
-php artisan cloudflare:purge --routes=home --routes=about --routes=users.show
+php artisan cloudflare:purge --route=home --route=about --route=users.show
 
 # Combine routes and paths
-php artisan cloudflare:purge /blog --routes=contact --routes=api.users.index
+php artisan cloudflare:purge /blog --route=contact --route=api.users.index
 ```
+
+### Purge by Prefix or Host
+
+Use `--prefix` when you want to purge every cached URL under a specific prefix without purging the whole zone. This is useful for deploys where one Cloudflare zone contains multiple sites or subdomains:
+
+```sh
+# Purge the marketing site only
+php artisan cloudflare:purge --prefix=https://www.example.com/
+
+# Purge multiple URL prefixes
+php artisan cloudflare:purge --prefix=https://www.example.com/blog/ --prefix=https://www.example.com/docs/
+```
+
+Use `--host` when you want to purge everything cached for a host:
+
+```sh
+# Purge all cached content for one host
+php artisan cloudflare:purge --host=www.example.com
+
+# Purge all cached content for multiple hosts
+php artisan cloudflare:purge --host=www.example.com --host=marketing.example.com
+```
+
+`--prefix` and `--host` are exclusive purge modes. They cannot be used together, and neither option can be combined with paths, `--route`, or `--all`.
 
 ### Scheduled Cache Purges
 
@@ -278,6 +308,9 @@ php artisan cloudflare:purge --route=home --route=users.index --schedule="tomorr
 
 # Schedule a full cache purge
 php artisan cloudflare:purge --all --force --schedule="2026-06-03 10:00:00"
+
+# Schedule a prefix purge
+php artisan cloudflare:purge --prefix=https://www.example.com/ --schedule="2026-06-03 10:00:00"
 ```
 
 Scheduled purges are stored on disk at the path configured by
@@ -345,6 +378,9 @@ add a `.well-known/*` rule to the wildcard section of your WAF rule.
 - Full URLs (starting with `http://` or `https://`) are used as-is
 - Unknown route names are silently skipped
 - Add `--force` with `--all` to skip the confirmation prompt
+- Use `--prefix` to purge every cached URL under a URL prefix
+- Use `--host` to purge everything cached for a host
+- `--prefix` and `--host` cannot be combined with each other, paths, routes, or `--all`
 - Cache purging requires different API permissions than WAF rule management
 
 ## Contributing

--- a/src/Commands/PurgeCache.php
+++ b/src/Commands/PurgeCache.php
@@ -19,6 +19,8 @@ class PurgeCache extends BaseCommand
     protected $signature = 'cloudflare:purge
                             {paths?* : Paths to purge (relative or full URLs). If omitted, purges all cache}
                             {--route=* : Route names to resolve and purge}
+                            {--prefix=* : URL prefixes to purge}
+                            {--host=* : Hosts to purge}
                             {--schedule= : Schedule the purge for a timestamp parseable by Carbon}
                             {--force : Do not prompt for confirmation when purging cache}
                             {--all : Purge all cached content from Cloudflare}';
@@ -31,6 +33,10 @@ class PurgeCache extends BaseCommand
             $this->fail($e->getMessage());
         }
 
+        if (! $this->validatePurgeOptions()) {
+            return;
+        }
+
         if ($this->option('schedule')) {
             $this->schedulePurge($this->option('schedule'));
 
@@ -41,6 +47,18 @@ class PurgeCache extends BaseCommand
             if ($this->option('force') || $this->confirm('Are you sure you want to purge all cached content from Cloudflare?')) {
                 $this->purgeAll();
             }
+
+            return;
+        }
+
+        if (! empty($this->option('prefix'))) {
+            $this->purgePrefixes($this->option('prefix'));
+
+            return;
+        }
+
+        if (! empty($this->option('host'))) {
+            $this->purgeHosts($this->option('host'));
 
             return;
         }
@@ -67,7 +85,7 @@ class PurgeCache extends BaseCommand
 
     protected function schedulePurge(string $timestamp): void
     {
-        if (! $this->option('all') && empty($this->argument('paths')) && empty($this->option('route'))) {
+        if (! $this->hasPurgeTarget()) {
             $this->warn('You must specify at least one path or route to purge. Or purge everything with `--all`.');
 
             return;
@@ -89,6 +107,8 @@ class PurgeCache extends BaseCommand
         app(ScheduledPurgeStore::class)->add($runAt, $this->getName(), [
             'paths' => $this->argument('paths'),
             '--route' => $this->option('route'),
+            '--prefix' => $this->option('prefix'),
+            '--host' => $this->option('host'),
             '--force' => (bool) $this->option('force'),
             '--all' => (bool) $this->option('all'),
         ]);
@@ -121,6 +141,36 @@ class PurgeCache extends BaseCommand
         }
 
         return array_unique($resolvedPaths);
+    }
+
+    protected function validatePurgeOptions(): bool
+    {
+        $usesUrlOptions = ! empty($this->argument('paths')) || ! empty($this->option('route')) || $this->option('all');
+        $usesPrefix = ! empty($this->option('prefix'));
+        $usesHost = ! empty($this->option('host'));
+
+        if ($usesPrefix && $usesHost) {
+            $this->warn('The `--prefix` and `--host` options cannot be used together.');
+
+            return false;
+        }
+
+        if (($usesPrefix || $usesHost) && $usesUrlOptions) {
+            $this->warn('The `--prefix` and `--host` options cannot be used with paths, routes, or `--all`.');
+
+            return false;
+        }
+
+        return true;
+    }
+
+    protected function hasPurgeTarget(): bool
+    {
+        return $this->option('all')
+            || ! empty($this->argument('paths'))
+            || ! empty($this->option('route'))
+            || ! empty($this->option('prefix'))
+            || ! empty($this->option('host'));
     }
 
     protected function processPaths(string $path): string
@@ -169,6 +219,58 @@ class PurgeCache extends BaseCommand
             $this->info($result->message);
             $this->line("  Purge ID: {$result->id}");
             $this->line('  Paths purged: '.count($paths));
+            $this->newLine();
+            $this->info('Cache purge completed successfully!');
+        } catch (CloudflareApiException $e) {
+            $this->handleApiException($e);
+        } catch (CloudflareException $e) {
+            $this->error('Failed to purge cache: '.$e->getMessage());
+            $this->newLine();
+            $this->warn('An unexpected error occurred. Please check your configuration and try again.');
+        }
+    }
+
+    protected function purgePrefixes(array $prefixes): void
+    {
+        $this->info('Purging URL prefixes from Cloudflare cache:');
+        foreach ($prefixes as $prefix) {
+            $this->line($prefix);
+        }
+        $this->newLine();
+
+        try {
+            $service = app(CachePurgeService::class);
+            $result = $service->purgePrefixes($prefixes);
+
+            $this->info($result->message);
+            $this->line("  Purge ID: {$result->id}");
+            $this->line('  Prefixes purged: '.count($prefixes));
+            $this->newLine();
+            $this->info('Cache purge completed successfully!');
+        } catch (CloudflareApiException $e) {
+            $this->handleApiException($e);
+        } catch (CloudflareException $e) {
+            $this->error('Failed to purge cache: '.$e->getMessage());
+            $this->newLine();
+            $this->warn('An unexpected error occurred. Please check your configuration and try again.');
+        }
+    }
+
+    protected function purgeHosts(array $hosts): void
+    {
+        $this->info('Purging hosts from Cloudflare cache:');
+        foreach ($hosts as $host) {
+            $this->line($host);
+        }
+        $this->newLine();
+
+        try {
+            $service = app(CachePurgeService::class);
+            $result = $service->purgeHosts($hosts);
+
+            $this->info($result->message);
+            $this->line("  Purge ID: {$result->id}");
+            $this->line('  Hosts purged: '.count($hosts));
             $this->newLine();
             $this->info('Cache purge completed successfully!');
         } catch (CloudflareApiException $e) {

--- a/src/Services/Cloudflare/CachePurgeService.php
+++ b/src/Services/Cloudflare/CachePurgeService.php
@@ -55,4 +55,25 @@ class CachePurgeService extends CloudflareService
             message: $message
         );
     }
+
+    public function purgePrefixes(array $prefixes): CachePurgeResult
+    {
+        return $this->purgeWildcard('prefixes', $prefixes, 'Successfully purged cached content matching prefixes');
+    }
+
+    public function purgeHosts(array $hosts): CachePurgeResult
+    {
+        return $this->purgeWildcard('hosts', $hosts, 'Successfully purged cached content matching hosts');
+    }
+
+    protected function purgeWildcard(string $key, array $values, string $message): CachePurgeResult
+    {
+        $response = $this->apiClient->post("zones/{$this->apiClient->getZoneId()}/purge_cache", [$key => $values]);
+        $result = $response->json('result');
+
+        return new CachePurgeResult(
+            id: $result['id'],
+            message: $message
+        );
+    }
 }

--- a/tests/Feature/Commands/PurgeCacheTest.php
+++ b/tests/Feature/Commands/PurgeCacheTest.php
@@ -133,6 +133,88 @@ class PurgeCacheTest extends TestCase
     }
 
     #[Test]
+    public function it_purges_prefixes(): void
+    {
+        Http::fake([
+            '*/purge_cache' => Http::response([
+                'success' => true,
+                'result' => ['id' => 'purge-prefixes-123'],
+            ]),
+        ]);
+
+        $this->artisan('cloudflare:purge', ['--prefix' => ['https://www.example.com/']])
+            ->expectsOutput('Purging URL prefixes from Cloudflare cache:')
+            ->expectsOutput('https://www.example.com/')
+            ->expectsOutput('Successfully purged cached content matching prefixes')
+            ->expectsOutput('  Purge ID: purge-prefixes-123')
+            ->expectsOutput('  Prefixes purged: 1')
+            ->expectsOutput('Cache purge completed successfully!')
+            ->assertExitCode(0);
+
+        Http::assertSent(function ($request) {
+            return $request->method() === 'POST'
+                && str_contains($request->url(), 'purge_cache')
+                && $request->data() === ['prefixes' => ['https://www.example.com/']];
+        });
+    }
+
+    #[Test]
+    public function it_purges_hosts(): void
+    {
+        Http::fake([
+            '*/purge_cache' => Http::response([
+                'success' => true,
+                'result' => ['id' => 'purge-hosts-123'],
+            ]),
+        ]);
+
+        $this->artisan('cloudflare:purge', ['--host' => ['www.example.com']])
+            ->expectsOutput('Purging hosts from Cloudflare cache:')
+            ->expectsOutput('www.example.com')
+            ->expectsOutput('Successfully purged cached content matching hosts')
+            ->expectsOutput('  Purge ID: purge-hosts-123')
+            ->expectsOutput('  Hosts purged: 1')
+            ->expectsOutput('Cache purge completed successfully!')
+            ->assertExitCode(0);
+
+        Http::assertSent(function ($request) {
+            return $request->method() === 'POST'
+                && str_contains($request->url(), 'purge_cache')
+                && $request->data() === ['hosts' => ['www.example.com']];
+        });
+    }
+
+    #[Test]
+    public function it_rejects_prefix_and_host_together(): void
+    {
+        Http::fake();
+
+        $this->artisan('cloudflare:purge', [
+            '--prefix' => ['https://www.example.com/'],
+            '--host' => ['www.example.com'],
+        ])
+            ->expectsOutput('The `--prefix` and `--host` options cannot be used together.')
+            ->assertExitCode(0);
+
+        Http::assertNothingSent();
+    }
+
+    #[Test]
+    public function it_rejects_prefix_with_url_options(): void
+    {
+        Http::fake();
+
+        $this->artisan('cloudflare:purge', [
+            'paths' => ['about'],
+            '--prefix' => ['https://www.example.com/'],
+        ])
+            ->expectsOutput('The `--prefix` and `--host` options cannot be used with paths, routes, or `--all`.')
+            ->assertExitCode(0);
+
+        Http::assertNothingSent();
+    }
+
+    #[Test]
     public function it_schedules_a_purge_without_calling_cloudflare(): void
     {
         Http::fake([

--- a/tests/Feature/Commands/PurgeCacheTest.php
+++ b/tests/Feature/Commands/PurgeCacheTest.php
@@ -142,9 +142,9 @@ class PurgeCacheTest extends TestCase
             ]),
         ]);
 
-        $this->artisan('cloudflare:purge', ['--prefix' => ['https://www.example.com/']])
+        $this->artisan('cloudflare:purge', ['--prefix' => ['www.example.com/']])
             ->expectsOutput('Purging URL prefixes from Cloudflare cache:')
-            ->expectsOutput('https://www.example.com/')
+            ->expectsOutput('www.example.com/')
             ->expectsOutput('Successfully purged cached content matching prefixes')
             ->expectsOutput('  Purge ID: purge-prefixes-123')
             ->expectsOutput('  Prefixes purged: 1')
@@ -154,7 +154,7 @@ class PurgeCacheTest extends TestCase
         Http::assertSent(function ($request) {
             return $request->method() === 'POST'
                 && str_contains($request->url(), 'purge_cache')
-                && $request->data() === ['prefixes' => ['https://www.example.com/']];
+                && $request->data() === ['prefixes' => ['www.example.com/']];
         });
     }
 
@@ -190,7 +190,7 @@ class PurgeCacheTest extends TestCase
         Http::fake();
 
         $this->artisan('cloudflare:purge', [
-            '--prefix' => ['https://www.example.com/'],
+            '--prefix' => ['www.example.com/'],
             '--host' => ['www.example.com'],
         ])
             ->expectsOutput('The `--prefix` and `--host` options cannot be used together.')
@@ -206,7 +206,7 @@ class PurgeCacheTest extends TestCase
 
         $this->artisan('cloudflare:purge', [
             'paths' => ['about'],
-            '--prefix' => ['https://www.example.com/'],
+            '--prefix' => ['www.example.com/'],
         ])
             ->expectsOutput('The `--prefix` and `--host` options cannot be used with paths, routes, or `--all`.')
             ->assertExitCode(0);

--- a/tests/Feature/Services/Cloudflare/CachePurgeServiceTest.php
+++ b/tests/Feature/Services/Cloudflare/CachePurgeServiceTest.php
@@ -84,7 +84,7 @@ class CachePurgeServiceTest extends TestCase
     #[Test]
     public function it_purges_prefixes_successfully(): void
     {
-        $prefixes = ['https://www.example.com/'];
+        $prefixes = ['www.example.com/'];
 
         Http::fake([
             '*/purge_cache' => Http::response([

--- a/tests/Feature/Services/Cloudflare/CachePurgeServiceTest.php
+++ b/tests/Feature/Services/Cloudflare/CachePurgeServiceTest.php
@@ -82,6 +82,58 @@ class CachePurgeServiceTest extends TestCase
     }
 
     #[Test]
+    public function it_purges_prefixes_successfully(): void
+    {
+        $prefixes = ['https://www.example.com/'];
+
+        Http::fake([
+            '*/purge_cache' => Http::response([
+                'success' => true,
+                'result' => ['id' => 'purge-prefixes-123'],
+            ]),
+        ]);
+
+        $service = new CachePurgeService($this->validConfig);
+        $result = $service->purgePrefixes($prefixes);
+
+        $this->assertInstanceOf(CachePurgeResult::class, $result);
+        $this->assertEquals('purge-prefixes-123', $result->id);
+        $this->assertStringContainsString('prefixes', $result->message);
+
+        Http::assertSent(function ($request) use ($prefixes) {
+            return $request->method() === 'POST'
+                && str_contains($request->url(), 'purge_cache')
+                && $request->data() === ['prefixes' => $prefixes];
+        });
+    }
+
+    #[Test]
+    public function it_purges_hosts_successfully(): void
+    {
+        $hosts = ['www.example.com'];
+
+        Http::fake([
+            '*/purge_cache' => Http::response([
+                'success' => true,
+                'result' => ['id' => 'purge-hosts-123'],
+            ]),
+        ]);
+
+        $service = new CachePurgeService($this->validConfig);
+        $result = $service->purgeHosts($hosts);
+
+        $this->assertInstanceOf(CachePurgeResult::class, $result);
+        $this->assertEquals('purge-hosts-123', $result->id);
+        $this->assertStringContainsString('hosts', $result->message);
+
+        Http::assertSent(function ($request) use ($hosts) {
+            return $request->method() === 'POST'
+                && str_contains($request->url(), 'purge_cache')
+                && $request->data() === ['hosts' => $hosts];
+        });
+    }
+
+    #[Test]
     public function it_purges_all_cache_when_empty_array_provided(): void
     {
         Http::fake([


### PR DESCRIPTION
## Problem

The purge cache command could purge everything, specific URLs, or routes, but it could not target Cloudflare’s prefix or host purge modes. That made deploy-time purges too broad for zones containing multiple sites or subdomains.

## Proposed solution

Added `--prefix` and `--host` options to `cloudflare:purge`. `--prefix` sends Cloudflare a `prefixes` purge payload, allowing users to clear everything under a URL prefix such as `www.example.com/foo/bar/`. `--host` sends a `hosts` purge payload, allowing users to clear cached content for one or more hostnames.

These options are treated as exclusive purge modes. They cannot be used together, and they cannot be combined with existing URL-style inputs like paths, `--route`, or `--all`, which keeps the command behavior explicit and prevents ambiguous Cloudflare payloads.

The new modes are covered by command and service tests, including payload assertions and validation for invalid option combinations. The README was also updated with examples for prefix, host, and scheduled prefix purges.