### PR TITLE
feat: support folio routes

### DIFF
--- a/src/Commands/GenerateWafRule.php
+++ b/src/Commands/GenerateWafRule.php
@@ -11,6 +11,7 @@ use JTSmith\Cloudflare\Exceptions\CloudflareApiException;
 use JTSmith\Cloudflare\Exceptions\CloudflareException;
 use JTSmith\Cloudflare\Exceptions\ConfigValidationException;
 use JTSmith\Cloudflare\Services\Cloudflare\WafRuleService;
+use Throwable;
 
 class GenerateWafRule extends BaseCommand
 {
@@ -32,7 +33,7 @@ class GenerateWafRule extends BaseCommand
         Artisan::call('route:list', ['--json' => true]);
         $json = Artisan::output();
 
-        $routes = $this->routes($json);
+        $routes = $this->routes($json, $this->folioRoutes());
         $rule = $this->generateRule($routes);
 
         $hostnames = config('cfcache.features.waf.hostnames', []);
@@ -49,10 +50,12 @@ class GenerateWafRule extends BaseCommand
         }
     }
 
-    public function routes(string $json): Collection
+    public function routes(string $json, Collection|array $additionalRoutes = []): Collection
     {
-        $routes = collect(json_decode($json, true))
+        $routes = collect(json_decode($json, true) ?: [])
+            ->reject(fn (array $route) => $this->isFolioFallbackRoute($route))
             ->pluck('uri')
+            ->merge($additionalRoutes)
             ->merge($this->publicPaths())
             ->merge($this->forcedAllowedPaths())
             ->unique()
@@ -75,6 +78,29 @@ class GenerateWafRule extends BaseCommand
             ->values();
 
         return $routes;
+    }
+
+    protected function folioRoutes(): Collection
+    {
+        if (! class_exists('Laravel\\Folio\\FolioManager')) {
+            return collect();
+        }
+
+        try {
+            Artisan::call('folio:list', ['--json' => true]);
+        } catch (Throwable) {
+            return collect();
+        }
+
+        return collect(json_decode(Artisan::output(), true) ?: [])
+            ->pluck('uri')
+            ->values();
+    }
+
+    protected function isFolioFallbackRoute(array $route): bool
+    {
+        return ($route['name'] ?? null) === 'laravel-folio'
+            && ($route['uri'] ?? null) === '{fallbackPlaceholder}';
     }
 
     public function publicPaths(): array

--- a/tests/Feature/Commands/GenerateWafRuleTest.php
+++ b/tests/Feature/Commands/GenerateWafRuleTest.php
@@ -122,6 +122,65 @@ class GenerateWafRuleTest extends TestCase
     }
 
     #[Test]
+    public function it_filters_out_the_folio_fallback_route_and_includes_folio_routes(): void
+    {
+        $command = new GenerateWafRule;
+
+        $json = json_encode([
+            [
+                'name' => 'laravel-folio',
+                'uri' => '{fallbackPlaceholder}',
+            ],
+            [
+                'name' => null,
+                'uri' => '/',
+            ],
+        ]);
+
+        $routes = $command->routes($json, [
+            '/blog/{slug}',
+            '/docs/{...path}',
+        ]);
+
+        $this->assertContains('/', $routes);
+        $this->assertContains('/blog/*', $routes);
+        $this->assertContains('/docs/*', $routes);
+        $this->assertNotContains('/*', $routes);
+    }
+
+    #[Test]
+    public function it_normalizes_folio_placeholder_routes(): void
+    {
+        $command = new GenerateWafRule;
+
+        $routes = $command->routes(json_encode([]), [
+            '/folio-placeholders/custom-key-alt/{user:name}',
+            '/folio-placeholders/custom-key/{user:email}',
+            '/folio-placeholders/fqcn-alt/{user}',
+            '/folio-placeholders/fqcn/{user}',
+            '/folio-placeholders/model-alt/{user}',
+            '/folio-placeholders/model/{user}',
+            '/folio-placeholders/multi-alt/{..paths}',
+            '/folio-placeholders/multi/{..ids}',
+            '/folio-placeholders/plain-alt/{slug}',
+            '/folio-placeholders/plain/{id}',
+        ]);
+
+        $this->assertContains('/folio-placeholders/custom-key-alt/*', $routes);
+        $this->assertContains('/folio-placeholders/custom-key/*', $routes);
+        $this->assertContains('/folio-placeholders/fqcn-alt/*', $routes);
+        $this->assertContains('/folio-placeholders/fqcn/*', $routes);
+        $this->assertContains('/folio-placeholders/model-alt/*', $routes);
+        $this->assertContains('/folio-placeholders/model/*', $routes);
+        $this->assertContains('/folio-placeholders/multi-alt/*', $routes);
+        $this->assertContains('/folio-placeholders/multi/*', $routes);
+        $this->assertContains('/folio-placeholders/plain-alt/*', $routes);
+        $this->assertContains('/folio-placeholders/plain/*', $routes);
+
+        $this->assertFalse($routes->contains(fn (string $route) => str_contains($route, '{')));
+    }
+
+    #[Test]
     public function it_fails_when_syncing_and_api_token_is_not_set(): void
     {
         Config::set('cfcache.api.token', null);


### PR DESCRIPTION
## Problem

We don't properly support Laravel Folio's default catch-all route properly

## Proposed solution

Detect if the user has Folio installed and if so, filter out the catch-all route and then fetch the list of Folio routes directly and iterate through them

## Fixes 

#24