### PR TITLE
ci: don't run CI in parallel mode due to `rename()` race condition

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,4 +60,9 @@ jobs:
           composer update --prefer-dist --no-interaction
 
       - name: Run tests
+        if: runner.os != 'Windows'
         run: vendor/bin/pest --parallel
+
+      - name: Run tests on Windows
+        if: runner.os == 'Windows'
+        run: vendor/bin/pest


### PR DESCRIPTION
## Problem 

Windows CI runs intermittently fail due to a race condition in `--parallel` mode with the `rename()` command in orchestra testbench

## Proposed solution

Don't run Pest in `--parallel` mode since the test suite should still run in under 1s.  

If this ever increases significantly, we can revisit.